### PR TITLE
Named Template Use Example

### DIFF
--- a/src/main/java/com/example/demo/UserController.java
+++ b/src/main/java/com/example/demo/UserController.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping(produces = "application/json")
 public class UserController {
+
+    private final UserService userService;
+
     @Autowired
-    private UserService userService;
     UserController(UserService userService) {
         this.userService = userService;
     }
@@ -17,10 +19,12 @@ public class UserController {
     public String index() {
         return "Greetings from the API!";
     }
+
     @GetMapping(value = "/users")
-    public List<User> getUsers() {
-        return this.userService.getAllUsers();
+    public ResponseEntity<List<User>> getUsers() {
+        return ResponseEntity.ok(userService.getAllUsers());
     }
+
     @GetMapping(value = "/users/{id}")
     public ResponseEntity getUser(@PathVariable String id) {
         User retUser = this.userService.getUserById(id);

--- a/src/main/java/com/example/demo/UserRepository.java
+++ b/src/main/java/com/example/demo/UserRepository.java
@@ -1,10 +1,11 @@
 package com.example.demo;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -12,24 +13,38 @@ import javax.sql.DataSource;
 import java.util.List;
 import java.util.Optional;
 
+
 @Repository
 public class UserRepository {
 
     private final Logger logger = LoggerFactory.getLogger(UserRepository.class);
-    private final ObjectMapper objectMapper;
 
     private final JdbcTemplate template;
     private final NamedParameterJdbcTemplate namedTemplate;
 
     @Autowired
-    public UserRepository(ObjectMapper objectMapper, DataSource dataSource) {
-        this.objectMapper = objectMapper;
+    public UserRepository(DataSource dataSource) {
         this.template = new JdbcTemplate(dataSource);
         this.namedTemplate = new NamedParameterJdbcTemplate(dataSource);
     }
 
     public List<User> getAllUsers() {
-        return null;
+
+        String query = """
+                SELECT id, first_name, last_name, email FROM users
+                                            WHERE email LIKE :emailFilter
+                """;
+
+        MapSqlParameterSource paramMap = new MapSqlParameterSource() {{
+            addValue("emailFilter", "%@example.com");
+        }};
+
+        try {
+            return namedTemplate.query(query, paramMap, new BeanPropertyRowMapper<>(User.class));
+        } catch (Exception e) {
+            logger.warn("Error getting all users - e={}", e.toString());
+            throw e;
+        }
     }
 
     public Optional<User> findById(String id) {


### PR DESCRIPTION
This is an example of how to implement the named template.

It's called a namedTemplate because it allows you to pass namedParameters to it, preventing SQL injection, which is a huge security risk.

The BeanPropertyRowMapper is a generic class that can infer the properties of the class passed in as an argument and try to deserialize the DB resultSet into those objects. If the properties don't line up directly with the DB column names, it is required to create a custom class that extends or implements beanPropertyRowMapper to define how the DB column names map to the object property names.